### PR TITLE
Variable detection fix

### DIFF
--- a/src/QueryCorrector.py
+++ b/src/QueryCorrector.py
@@ -58,7 +58,7 @@ class QueryCorrector:
         res = {}
         for node in nodes:
             parts = node.split(":")
-            if parts == "":
+            if parts[0] == "":
                 continue
             variable = parts[0]
             if variable not in res:


### PR DESCRIPTION
This small mistake makes in some cases the detected variable dict to contain in key `""` (empty string) all the nodes that don't have a variable, and in the end it doesn't correct the query properly.